### PR TITLE
Refatora toda a logica de mudança de senha para distribuir as responsabilidades entre os serviços.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-EXPO_PUBLIC_API_URL="sua_url_aqui"
+EXPO_PUBLIC_API_URL="sua_url_aqui (http://192.168.0.99:3333)"
+EXPO_PUBLIC_API_PREFIX="prefixo_da_api (/api/)"

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
-EXPO_PUBLIC_API_BASE_URL="sua_url_aqui (http://192.168.0.99:3333)"
-EXPO_PUBLIC_API_PREFIX="prefixo_da_api (/api/)"
+# Example URL: http://192.168.0.99:3333
+EXPO_PUBLIC_API_BASE_URL="sua_url_aqui"
+# Example prefix: /api/
+EXPO_PUBLIC_API_PREFIX="prefixo_da_api"

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-EXPO_PUBLIC_API_URL="sua_url_aqui (http://192.168.0.99:3333)"
+EXPO_PUBLIC_API_BASE_URL="sua_url_aqui (http://192.168.0.99:3333)"
 EXPO_PUBLIC_API_PREFIX="prefixo_da_api (/api/)"

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ Polvo App é uma aplicação mobile desenvolvida com React Native e Expo para in
    ```bash
    cp .env.example .env
    ```
-4. Configure a variável `EXPO_PUBLIC_API_URL` no arquivo `.env` com a URL do backend
+4. Configure a variável `EXPO_PUBLIC_API_BASE_URL` e `EXPO_PUBLIC_API_PREFIX` no arquivo `.env` com a URL do backend
 
    ```env
-   EXPO_PUBLIC_API_URL="http://{SEU-IPV4}:{PORTA-DA-APLICAÇÃO}/"
+   EXPO_PUBLIC_API_BASE_URL="http://192.168.0.99:3333"
+   EXPO_PUBLIC_API_PREFIX="/api/"
    ```
 
 ### Executando o Projeto

--- a/app/(auth)/passwordRecovery/index.tsx
+++ b/app/(auth)/passwordRecovery/index.tsx
@@ -14,7 +14,7 @@ import { AppButton } from '~/components/app/AppButton';
 import { AppInput } from '~/components/app/AppInput';
 import { AppModal } from '~/components/app/AppModal';
 import { AppTextButton } from '~/components/app/AppTextButton';
-import api from '~/lib/api';
+import { authService } from '~/lib/services/auth';
 
 import usePasswordRecoveryCooldown from './(hooks)/usePasswordRecoveryCooldown';
 
@@ -47,19 +47,20 @@ export default function PasswordRecovery() {
   const onSubmit = async (data: PasswordRecoveryForm) => {
     setIsLoading(true);
     try {
-      const response = await api.post('/api/user/resetPassword/token', {
-        email: data.email,
-      });
-      if (!response.data) {
+      const response = await authService.sendPasswordResetEmail(data.email);
+
+      if (!response) {
         alert(
           'Erro ao enviar o e-mail de recuperação. Tente novamente mais tarde.',
         );
         return;
       }
+
       setModalVisible(true);
       await startCooldown();
     } catch (error) {
-      alert('Erro desconhecido. Tente novamente mais tarde.' + error);
+      alert('Erro desconhecido. Tente novamente mais tarde.');
+      console.error(error);
     } finally {
       setIsLoading(false);
     }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,16 +2,17 @@ import axios from 'axios';
 
 import { tokenManager } from './auth/tokenManager';
 
-export const API_URL = process.env.EXPO_PUBLIC_API_URL;
+export const BASE_API_URL = process.env.EXPO_PUBLIC_API_BASE_URL;
+export const API_PREFIX = process.env.EXPO_PUBLIC_API_PREFIX;
 
-if (!API_URL) {
+if (!BASE_API_URL || !API_PREFIX) {
   throw new Error(
-    'API_URL is not defined. Please set it in your environment variables.',
+    'BASE_API_URL or API_PREFIX is not defined. Please set it in your environment variables.',
   );
 }
 
 const api = axios.create({
-  baseURL: API_URL,
+  baseURL: BASE_API_URL + API_PREFIX,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/lib/services/auth.ts
+++ b/lib/services/auth.ts
@@ -15,4 +15,17 @@ export const authService = {
       throw error;
     }
   },
+
+  async sendPasswordResetEmail(email: string) {
+    try {
+      const response = await api.post('/user/resetPassword/token', {
+        email,
+      });
+
+      return response.data;
+    } catch (error) {
+      console.error('Erro ao enviar e-mail de recuperação de senha:', error);
+      throw error;
+    }
+  },
 };

--- a/lib/services/auth.ts
+++ b/lib/services/auth.ts
@@ -8,7 +8,7 @@ interface LoginProps {
 export const authService = {
   async login(data: LoginProps) {
     try {
-      const response = await api.post('/api/login/hoken', data);
+      const response = await api.post('/login/hoken', data);
       return response.data;
     } catch (error) {
       console.error('Erro ao fazer login:', error);

--- a/lib/services/auth.ts
+++ b/lib/services/auth.ts
@@ -1,0 +1,18 @@
+import api from '../api';
+
+interface LoginProps {
+  email: string;
+  password: string;
+}
+
+export const authService = {
+  async login(data: LoginProps) {
+    try {
+      const response = await api.post('/auth/login', data);
+      return response.data;
+    } catch (error) {
+      console.error('Erro ao fazer login:', error);
+      throw error;
+    }
+  },
+};

--- a/lib/services/auth.ts
+++ b/lib/services/auth.ts
@@ -1,14 +1,14 @@
 import api from '../api';
 
 interface LoginProps {
-  email: string;
+  login: string;
   password: string;
 }
 
 export const authService = {
   async login(data: LoginProps) {
     try {
-      const response = await api.post('/auth/login', data);
+      const response = await api.post('/api/login/hoken', data);
       return response.data;
     } catch (error) {
       console.error('Erro ao fazer login:', error);

--- a/lib/services/storage.ts
+++ b/lib/services/storage.ts
@@ -1,0 +1,54 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+// eslint-disable-next-line import/order
+import * as SecureStore from 'expo-secure-store';
+import { User } from '../auth/AuthContext';
+import { tokenManager } from '../auth/tokenManager';
+
+export const STORAGE_KEYS = {
+  USER_DATA: '@polvo-app:user-data',
+  AUTH_TOKEN: 'polvoappauthkey',
+  ACCESS_KEY: 'polvoappaccesskey',
+};
+
+export const storageService = {
+  // User data operations
+  async saveUser(userData: User): Promise<void> {
+    await AsyncStorage.setItem(
+      STORAGE_KEYS.USER_DATA,
+      JSON.stringify(userData),
+    );
+    await this.saveTokens(userData.authenticationKey, userData.accessKey);
+  },
+
+  async getUser(): Promise<User | null> {
+    const raw = await AsyncStorage.getItem(STORAGE_KEYS.USER_DATA);
+    return raw ? JSON.parse(raw) : null;
+  },
+
+  // Token operations
+  async saveTokens(authToken: string, accessKey: string): Promise<void> {
+    await SecureStore.setItemAsync(STORAGE_KEYS.AUTH_TOKEN, authToken);
+    await SecureStore.setItemAsync(STORAGE_KEYS.ACCESS_KEY, accessKey);
+
+    // Update token manager
+    tokenManager.setAuthToken(authToken);
+    tokenManager.setAccessKey(accessKey);
+  },
+
+  async getTokens(): Promise<{
+    authToken: string | null;
+    accessKey: string | null;
+  }> {
+    const authToken = await SecureStore.getItemAsync(STORAGE_KEYS.AUTH_TOKEN);
+    const accessKey = await SecureStore.getItemAsync(STORAGE_KEYS.ACCESS_KEY);
+    return { authToken, accessKey };
+  },
+
+  // Clear all data
+  async clearStorage(): Promise<void> {
+    await AsyncStorage.removeItem(STORAGE_KEYS.USER_DATA);
+    await SecureStore.deleteItemAsync(STORAGE_KEYS.AUTH_TOKEN);
+    await SecureStore.deleteItemAsync(STORAGE_KEYS.ACCESS_KEY);
+    tokenManager.clearTokens();
+  },
+};

--- a/lib/services/storage.ts
+++ b/lib/services/storage.ts
@@ -51,4 +51,17 @@ export const storageService = {
     await SecureStore.deleteItemAsync(STORAGE_KEYS.ACCESS_KEY);
     tokenManager.clearTokens();
   },
+
+  // General storage methods
+  async setItem(key: string, value: string): Promise<void> {
+    await AsyncStorage.setItem(key, value);
+  },
+
+  async getItem(key: string): Promise<string | null> {
+    return await AsyncStorage.getItem(key);
+  },
+
+  async removeItem(key: string): Promise<void> {
+    await AsyncStorage.removeItem(key);
+  },
 };


### PR DESCRIPTION
## ESSA TASK DEPENDE COMPLETAMENTE NA #2 CONSIDERE VE-LA ANTES.

Esta PR dá continuidade ao trabalho de refatoração iniciado anteriormente, focando especificamente na funcionalidade de recuperação de senha.

### Principais Mudanças:

1.  **Movimentação da Lógica de API para `authService` (`lib/services/auth.ts`):**
    * A chamada de API para solicitar o e-mail de redefinição de senha (`/user/resetPassword/token`) foi movida da tela `PasswordRecovery` para o `authService`.
    * Foi criada a função `authService.sendPasswordResetEmail(email)`.
    * **Comentário:** Centralizar todas as interações de API relacionadas à autenticação e gestão de usuário no `authService` é fundamental. Isso remove a dependência direta do `axios` e da estrutura da API dos componentes de UI, facilitando futuras alterações e testes.

2.  **Extensão do `storageService` (`lib/services/storage.ts`):**
    * Foram adicionados métodos genéricos (`setItem`, `getItem`, `removeItem`) ao `storageService` para interagir com o `AsyncStorage`.
    * **Comentário:** Embora o `storageService` já gerenciasse dados específicos (usuário, tokens), essa extensão o torna uma camada de abstração mais completa para o `AsyncStorage`. Isso é útil não apenas para o `usePasswordRecoveryCooldown`, mas para qualquer outra necessidade futura de armazenamento simples, garantindo que todo o acesso ao `AsyncStorage` passe por um ponto centralizado.

3.  **Refatoração do Hook `usePasswordRecoveryCooldown` (`app/(auth)/passwordRecovery/(hooks)/usePasswordRecoveryCooldown.ts`):**
    * O hook agora utiliza `storageService.getItem` e `storageService.setItem` em vez de chamar `AsyncStorage` diretamente.
    * **Comentário:** Alinhar o hook com o `storageService` o torna mais testável e desacoplado da implementação de armazenamento. Se um dia decidirmos mudar como o cooldown é persistido, apenas o `storageService` precisará ser ajustado.

4.  **Atualização da Tela `PasswordRecovery` (`app/(auth)/passwordRecovery/index.tsx`):**
    * A tela agora chama `authService.sendPasswordResetEmail` em vez de fazer a chamada `api.post` diretamente.
    * A interação com o hook `usePasswordRecoveryCooldown` permanece, mas o hook em si está mais limpo.
    * **Comentário:** A tela agora se concentra em suas responsabilidades primárias: renderizar a UI, gerenciar o estado do formulário e orquestrar as ações do usuário, delegando a lógica de negócio (chamada de API) para o serviço apropriado.